### PR TITLE
Fix for 'create' command

### DIFF
--- a/lib/cli.coffee
+++ b/lib/cli.coffee
@@ -315,7 +315,7 @@ switch command
           config.version = version
           config.author = {name: user.name, email: user.email}
           config.developers = {}
-          config.developers[user.admin_uid] = 'admin'
+          config.developers[user.uid] = 'admin'
           config = CSON.stringifySync(config).replace /\n\n/g, '\n'
           fs.writeFileSync config_path, config
 


### PR DESCRIPTION
```
$ dobi create testing12@1.0 library
[dobi] authenticating user

/usr/local/lib/node_modules/dobi/lib/cli.coffee:398
            config.author.name = user.name;
                               ^
TypeError: Cannot set property 'name' of undefined
  at /usr/local/lib/node_modules/dobi/lib/cli.coffee:316:11
  at WriteStream.cb (/usr/local/lib/node_modules/dobi/node_modules/ncp/lib/ncp.js:224:37)
  at WriteStream.g (events.js:180:16)
  at WriteStream.EventEmitter.emit (events.js:117:20)
  at finishMaybe (_stream_writable.js:360:12)
  at afterWrite (_stream_writable.js:280:5)
  at onwrite (_stream_writable.js:270:7)
  at WritableState.onwrite (_stream_writable.js:97:5)
  at fs.js:1683:5
  at Object.wrapper [as oncomplete] (fs.js:510:5)
```
