### PR TITLE
Dobi: Update lint to allow for file/directory

### DIFF
--- a/lib/cli.coffee
+++ b/lib/cli.coffee
@@ -38,7 +38,7 @@ where <command> [command-specific-options] is one of:
   docs                              open the dobi docs
   help                              show usage
   init                              initialize a workspace
-  lint                              lint package or -f <file> to lint file
+  lint <id@version> | -p <path>     lint package or -p <path> to lint file/dir
   login                             authenticate your user
   logout                            deauthenticate your user
   open <site-slug>                  open a site


### PR DESCRIPTION
dobi lint -p path_to_file.jason
dobi lint -p path/to/directory/jason

it won't go through directories if they're named `.git` or `node_modules` 
# file test

``` shell
stevenanderson ~/dev/lessthan3/dobi/lib
$ mydobi lint -p dobi-lint.coffee
[dobi-lint] dobi-lint.coffee
[dobi-lint] #27: Line contains inconsistent indentation
[dobi-lint]      read = (filename) ->

[dobi]
[dobi]  ----------------------------------------------
[dobi] |         * * * E P I C    F A I L * * *       |
[dobi] |                                              |
[dobi] | Some files failed dobi lint validation.      |
[dobi] |                                              |
[dobi]  ----------------------------------------------
[dobi]
```
# directory test

``` shell
stevenanderson ~/dev/lessthan3/dobi-messenger
$ mydobi lint -p .
[dobi-lint] messenger.coffee
[dobi-lint] #29: Operators must be spaced properly
[dobi-lint]      expires: Date.now() + 1000*60*60*24*30

[dobi-lint] #29: Operators must be spaced properly
[dobi-lint]      expires: Date.now() + 1000*60*60*24*30

[dobi-lint] #29: Operators must be spaced properly
[dobi-lint]      expires: Date.now() + 1000*60*60*24*30

[dobi-lint] #29: Operators must be spaced properly
[dobi-lint]      expires: Date.now() + 1000*60*60*24*30

[dobi-lint] #56: console.log statements are not allowed
[dobi-lint]      console.log "ERROR setting #{property}: #{err}"

[dobi-lint] #133: Operators must be spaced properly
[dobi-lint]       get 'state', (state={}) ->

[dobi-lint] #137: An empty line is required before a 'when' statement
[dobi-lint]       when '$admin'

[dobi-lint] #139: An empty line is required before a 'when' statement
[dobi-lint]       when '$blacklist'

[dobi-lint] #141: An empty line is required before a 'when' statement
[dobi-lint]       when '$history'

[dobi-lint] #143: An empty line is required before a 'when' statement
[dobi-lint]       when '$limit'

[dobi-lint] #145: An empty line is required before a 'when' statement
[dobi-lint]       when '$inc'

[dobi-lint] #149: An empty line is required before a 'when' statement
[dobi-lint]       when '$reset'

[dobi-lint] #154: An empty line is required before a 'when' statement
[dobi-lint]       when '$secure'

[dobi-lint] #156: An empty line is required before a 'when' statement
[dobi-lint]       when '$unique'

[dobi-lint] #158: An empty line is required before a 'when' statement
[dobi-lint]       when '$whitelist'

[dobi-lint] #168: Operators must be spaced properly
[dobi-lint]       get 'state/last_message', (last_message=false) ->

[dobi-lint] #203: console.log statements are not allowed
[dobi-lint]       return console.log err if err and DEBUG

[dobi-lint] #208: console.log statements are not allowed
[dobi-lint]       return console.log err if err and DEBUG

[dobi-lint] #217: Too many empty lines in a row. Only 1 allowed

[dobi]
[dobi]  ----------------------------------------------
[dobi] |         * * * E P I C    F A I L * * *       |
[dobi] |                                              |
[dobi] | Some files failed dobi lint validation.      |
[dobi] |                                              |
[dobi]  ----------------------------------------------
[dobi]
```
